### PR TITLE
Update OkHttpClient with User-Agent

### DIFF
--- a/lib/network/src/main/java/com/tonapps/network/OkHttpClient.kt
+++ b/lib/network/src/main/java/com/tonapps/network/OkHttpClient.kt
@@ -25,7 +25,9 @@ import org.json.JSONObject
 
 private fun requestBuilder(url: String): Request.Builder {
     val builder = Request.Builder()
+    val versionName = BuildConfig.VERSION_NAME // Get the version dynamically
     builder.url(url)
+    builder.header("User-Agent", "Tonkeeper Android/$versionName") // Add custom User-Agent with version
     return builder
 }
 


### PR DESCRIPTION
In the previous app version, `?utm_source=tonkeeper` was automatically added to all visited websites.

We suggest keeping this approach, or alternatively, implementing a custom `User-Agent` to identify the Tonkeeper Browser and create a better experience for all app users with dApps.

Feature request: https://github.com/tonkeeper/android/issues/102